### PR TITLE
Reset onboarding on sign out and add confirm password sign-up screen

### DIFF
--- a/navigation/OnboardingNavigator.js
+++ b/navigation/OnboardingNavigator.js
@@ -1,5 +1,6 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import AuthStepScreen from "../screens/onboarding/AuthStepScreen";
+import SignUpStepScreen from "../screens/onboarding/SignUpStepScreen";
 import EmailStepScreen from "../screens/onboarding/EmailStepScreen";
 import NotificationsStepScreen from "../screens/onboarding/NotificationsStepScreen";
 import SupabaseStepScreen from "../screens/onboarding/SupabaseStepScreen";
@@ -19,6 +20,11 @@ const OnboardingNavigator = () => (
             name="AuthStep"
             component={AuthStepScreen}
             options={{ title: "Welcome" }}
+        />
+        <Stack.Screen
+            name="SignUpStep"
+            component={SignUpStepScreen}
+            options={{ title: "Create Account" }}
         />
         <Stack.Screen
             name="EmailStep"

--- a/screens/ProfileScreen.js
+++ b/screens/ProfileScreen.js
@@ -7,9 +7,16 @@ const ProfileScreen = () => {
     const { user, signOut } = useAuth();
     const { resetOnboarding } = useOnboarding();
 
+    const handleSignOut = async () => {
+        try {
+            await signOut();
+        } finally {
+            await resetOnboarding();
+        }
+    };
+
     const handleReset = async () => {
-        await resetOnboarding();
-        await signOut();
+        await handleSignOut();
     };
 
     return (
@@ -28,7 +35,7 @@ const ProfileScreen = () => {
             <TouchableOpacity style={styles.button}>
                 <Text style={styles.buttonText}>App Settings</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={styles.signOutButton} onPress={signOut}>
+            <TouchableOpacity style={styles.signOutButton} onPress={handleSignOut}>
                 <Text style={styles.signOutText}>Sign Out</Text>
             </TouchableOpacity>
         </View>

--- a/screens/onboarding/SignUpStepScreen.js
+++ b/screens/onboarding/SignUpStepScreen.js
@@ -10,10 +10,11 @@ import {
 import { useAuth } from "../../contexts/AuthContext";
 import { COLORS } from "../../config";
 
-const AuthStepScreen = ({ navigation }) => {
-    const { user, signIn, loading } = useAuth();
+const SignUpStepScreen = ({ navigation }) => {
+    const { user, signUp, loading } = useAuth();
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState(null);
 
@@ -24,12 +25,16 @@ const AuthStepScreen = ({ navigation }) => {
     }, [navigation, user]);
 
     const handleSubmit = async () => {
+        if (password !== confirmPassword) {
+            setError("Passwords do not match");
+            return;
+        }
+
         setSubmitting(true);
         setError(null);
         try {
-            const payload = { email, password };
-            const { error: signInError } = await signIn(payload);
-            if (signInError) throw signInError;
+            const { error: signUpError } = await signUp({ email, password });
+            if (signUpError) throw signUpError;
         } catch (err) {
             setError(err.message);
         } finally {
@@ -39,7 +44,7 @@ const AuthStepScreen = ({ navigation }) => {
 
     return (
         <View style={styles.container}>
-            <Text style={styles.title}>Sign in with Supabase</Text>
+            <Text style={styles.title}>Create your account</Text>
             <TextInput
                 style={styles.input}
                 placeholder="Email"
@@ -57,6 +62,14 @@ const AuthStepScreen = ({ navigation }) => {
                 value={password}
                 onChangeText={setPassword}
             />
+            <TextInput
+                style={styles.input}
+                placeholder="Confirm Password"
+                placeholderTextColor={COLORS.subText}
+                secureTextEntry
+                value={confirmPassword}
+                onChangeText={setConfirmPassword}
+            />
             {error ? <Text style={styles.error}>{error}</Text> : null}
             <TouchableOpacity
                 style={styles.button}
@@ -66,16 +79,14 @@ const AuthStepScreen = ({ navigation }) => {
                 {submitting ? (
                     <ActivityIndicator color={COLORS.text} />
                 ) : (
-                    <Text style={styles.buttonText}>Sign In</Text>
+                    <Text style={styles.buttonText}>Create Account</Text>
                 )}
             </TouchableOpacity>
             <TouchableOpacity
                 style={styles.switcher}
-                onPress={() => navigation.navigate("SignUpStep")}
+                onPress={() => navigation.goBack()}
             >
-                <Text style={styles.switcherText}>
-                    Don't have an account? Sign up
-                </Text>
+                <Text style={styles.switcherText}>Already have an account? Sign in</Text>
             </TouchableOpacity>
         </View>
     );
@@ -126,4 +137,4 @@ const styles = StyleSheet.create({
     },
 });
 
-export default AuthStepScreen;
+export default SignUpStepScreen;


### PR DESCRIPTION
## Summary
- reset the onboarding state whenever a user signs out so the flow returns to the authentication screens
- add a dedicated sign-up screen with confirm password support
- update the onboarding navigator and sign-in screen to link to the new sign-up step

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd0a4f4d5c832db30b7e1c43e1b581