### PR TITLE
Stabilize user settings updates to prevent reload oscillation

### DIFF
--- a/contexts/UserSettingsContext.js
+++ b/contexts/UserSettingsContext.js
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 
 const STORAGE_KEY = "userSettings";
 
@@ -33,11 +33,14 @@ export const UserSettingsProvider = ({ children }) => {
         load();
     }, []);
 
-    const updateSettings = async (updates) => {
-        const next = { ...settings, ...updates };
-        setSettings(next);
+    const updateSettings = useCallback(async (updates) => {
+        let next;
+        setSettings((prev) => {
+            next = { ...prev, ...updates };
+            return next;
+        });
         await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-    };
+    }, []);
 
     return (
         <UserSettingsContext.Provider value={{ settings, loading, updateSettings }}>


### PR DESCRIPTION
## Summary
- wrap the user settings updater in `useCallback` so its reference remains stable
- update settings state via a functional setter and persist the computed value to AsyncStorage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cec95d47f0832da2dcfefd4014d075