### PR TITLE
Fix Gmail PKCE generation and add Supabase helper SQL

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -43,6 +43,7 @@
      with check (auth.uid() = user_id);
    ```
 3. The existing `transactions` and `categories` tables should continue to run on either the default Supabase instance or a custom instance configured by the user during onboarding.
+4. After applying the base schema, run the statements in `toAddDatabase.sql` to install helper functions (summary aggregations and the trigger that keeps `user_settings.updated_at` in sync).
 
 ## Gmail email interception setup
 

--- a/contexts/GmailContext.js
+++ b/contexts/GmailContext.js
@@ -89,9 +89,25 @@ export const useGmail = () => {
 };
 
 const createPKCECodes = async () => {
-    const codeVerifier = await AuthSession.generateRandomAsync(128);
+    const codeVerifier = generateCodeVerifier();
     const codeChallenge = await deriveCodeChallenge(codeVerifier);
     return { codeVerifier, codeChallenge };
+};
+
+const PKCE_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+
+const generateCodeVerifier = (length = 128) => {
+    const randomBytes = new Uint8Array(length);
+    try {
+        Crypto.getRandomValues(randomBytes);
+    } catch (error) {
+        for (let index = 0; index < length; index += 1) {
+            randomBytes[index] = Math.floor(Math.random() * 256);
+        }
+    }
+    return Array.from(randomBytes)
+        .map((byte) => PKCE_CHARSET[byte % PKCE_CHARSET.length])
+        .join("");
 };
 
 const deriveCodeChallenge = async (codeVerifier) => {

--- a/services/gmailService.js
+++ b/services/gmailService.js
@@ -130,7 +130,13 @@ class GmailService {
         );
 
         const parsed = detailed
-            .map((email) => ({ email, transaction: parseEmail(email) }))
+            .map((email) => {
+                console.log(
+                    "📧 Full Gmail message received:",
+                    JSON.stringify(email, null, 2)
+                );
+                return { email, transaction: parseEmail(email) };
+            })
             .filter(({ transaction }) => transaction && transaction.amount > 0)
             .map(({ email, transaction }) => ({
                 ...transaction,

--- a/toAddDatabase.sql
+++ b/toAddDatabase.sql
@@ -1,0 +1,77 @@
+-- Additional functions and helpers for the Supabase database.
+-- Run this file after the base schema in SCHEMA.sql has been applied.
+
+-- Keeps user_settings.updated_at current whenever the row is changed.
+create or replace function public.touch_user_settings_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+    new.updated_at = timezone('utc', now());
+    return new;
+end;
+$$;
+
+drop trigger if exists user_settings_updated_at_trigger on public.user_settings;
+create trigger user_settings_updated_at_trigger
+before update on public.user_settings
+for each row
+execute function public.touch_user_settings_updated_at();
+
+-- Returns income, expenses, and balance totals for a user within a range.
+create or replace function public.get_monthly_summary(
+    p_user_id uuid,
+    p_start timestamptz,
+    p_end timestamptz
+)
+returns table(
+    income numeric,
+    expenses numeric,
+    balance numeric
+)
+language sql
+stable
+as $$
+    with totals as (
+        select
+            coalesce(sum(case when direction = 'incoming' then amount end), 0) as income,
+            coalesce(sum(case when direction = 'outgoing' then amount end), 0) as expenses
+        from public.transactions
+        where user_id = p_user_id
+          and transacted_at >= p_start
+          and transacted_at < p_end
+    )
+    select income, expenses, income - expenses as balance
+    from totals;
+$$;
+
+-- Provides per-category spend within a range to complement the summary view.
+create or replace function public.get_category_usage(
+    p_user_id uuid,
+    p_start timestamptz,
+    p_end timestamptz
+)
+returns table(
+    category_id bigint,
+    category_name text,
+    monthly_budget numeric,
+    spent numeric
+)
+language sql
+stable
+as $$
+    select
+        c.id as category_id,
+        c.name as category_name,
+        c.monthly_budget,
+        coalesce(sum(case when t.direction = 'outgoing' then t.amount end), 0) as spent
+    from public.categories c
+    left join public.transactions t
+        on t.category_id = c.id
+       and t.user_id = p_user_id
+       and t.transacted_at >= p_start
+       and t.transacted_at < p_end
+    where c.user_id = p_user_id
+    group by c.id, c.name, c.monthly_budget
+    order by c.created_at;
+$$;


### PR DESCRIPTION
## Summary
- replace the removed AuthSession.generateRandomAsync call with a local PKCE code verifier generator
- log the full Gmail payload before parsing so debugging incoming mail is easier
- add a SQL helper script with triggers and summary functions and document running it in TODO.md

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68edb60161ac832da76aaa2c6bb4725b